### PR TITLE
feat(scan_engines): implement Scan Engines API module (Issue #68)

### DIFF
--- a/docs/SCAN_ENGINES_API.md
+++ b/docs/SCAN_ENGINES_API.md
@@ -1,0 +1,468 @@
+# Scan Engines API Documentation
+
+## Overview
+
+The Scan Engines API module provides comprehensive functionality for managing scan engines and engine pools in Rapid7 InsightVM. This includes creating, updating, and deleting engines and pools, monitoring engine health, and managing site assignments.
+
+## Quick Start
+
+```python
+from rapid7 import InsightVMClient
+
+# Initialize client
+client = InsightVMClient()
+
+# List all scan engines
+engines = client.scan_engines.list()
+for engine in engines['resources']:
+    print(f"{engine['name']}: {engine['status']}")
+
+# Get specific engine details
+engine = client.scan_engines.get(engine_id=6)
+print(f"Engine: {engine['name']} at {engine['address']}")
+
+# Create an engine pool
+pool = client.scan_engines.create_pool(
+    name="Production Pool",
+    engine_ids=[1, 2, 3]
+)
+print(f"Created pool: {pool['id']}")
+```
+
+## Scan Engine Operations
+
+### List All Scan Engines
+
+List all scan engines available for scanning:
+
+```python
+engines = client.scan_engines.list()
+
+for engine in engines['resources']:
+    print(f"ID: {engine['id']}")
+    print(f"Name: {engine['name']}")
+    print(f"Address: {engine['address']}")
+    print(f"Port: {engine['port']}")
+    print(f"Status: {engine['status']}")
+    print(f"Product Version: {engine['productVersion']}")
+    print(f"Content Version: {engine['contentVersion']}")
+    print(f"Sites: {engine['sites']}")
+    print(f"Is AWS Pre-Auth: {engine['isAWSPreAuthEngine']}")
+    print("---")
+```
+
+### Get Scan Engine Details
+
+Retrieve detailed information for a specific scan engine:
+
+```python
+engine = client.scan_engines.get(engine_id=6)
+
+print(f"Engine Name: {engine['name']}")
+print(f"Address: {engine['address']}:{engine['port']}")
+print(f"Status: {engine['status']}")
+print(f"Assigned to {len(engine['sites'])} sites")
+```
+
+### Update Scan Engine
+
+Update scan engine configuration:
+
+```python
+result = client.scan_engines.update(
+    engine_id=6,
+    name="Updated Engine Name"
+)
+```
+
+### Delete Scan Engine
+
+Remove a scan engine from the system:
+
+```python
+# Engine must not be actively scanning or assigned to sites
+result = client.scan_engines.delete(engine_id=6)
+```
+
+## Engine Site Operations
+
+### Get Sites Assigned to Engine
+
+List all sites assigned to a specific scan engine:
+
+```python
+sites = client.scan_engines.get_sites(
+    engine_id=6,
+    page=0,
+    size=50,
+    sort=['name,ASC']
+)
+
+print(f"Total sites: {sites['page']['totalResources']}")
+for site in sites['resources']:
+    print(f"- {site['name']} (ID: {site['id']})")
+```
+
+### Get Scans Run on Engine
+
+Retrieve scans that have been executed on a specific engine:
+
+```python
+scans = client.scan_engines.get_scans(
+    engine_id=6,
+    page=0,
+    size=20
+)
+
+for scan in scans['resources']:
+    print(f"Scan {scan['id']}: {scan['status']}")
+```
+
+## Engine Pool Operations
+
+### List All Engine Pools
+
+List all available engine pools:
+
+```python
+pools = client.scan_engines.list_pools()
+
+for pool in pools['resources']:
+    print(f"Pool: {pool['name']}")
+    print(f"Engines: {pool['engines']}")
+    print(f"Sites: {pool['sites']}")
+    print("---")
+```
+
+### Get Engine Pool Details
+
+Retrieve details for a specific engine pool:
+
+```python
+pool = client.scan_engines.get_pool(pool_id=6)
+
+print(f"Pool Name: {pool['name']}")
+print(f"Engines in pool: {pool['engines']}")
+print(f"Sites using pool: {pool['sites']}")
+```
+
+### Create Engine Pool
+
+Create a new engine pool for load balancing:
+
+```python
+# Create pool with engines
+pool = client.scan_engines.create_pool(
+    name="Production Pool",
+    engine_ids=[1, 2, 3]
+)
+print(f"Created pool {pool['id']}")
+
+# Create empty pool (add engines later)
+pool = client.scan_engines.create_pool(
+    name="Development Pool"
+)
+```
+
+### Update Engine Pool
+
+Update an existing engine pool:
+
+```python
+result = client.scan_engines.update_pool(
+    pool_id=6,
+    name="Updated Pool Name",
+    engines=[1, 2, 3, 4, 5]
+)
+```
+
+### Delete Engine Pool
+
+Remove an engine pool:
+
+```python
+result = client.scan_engines.delete_pool(pool_id=6)
+```
+
+### Manage Pool Engines
+
+Get and set engines in a pool:
+
+```python
+# Get current engines in pool
+engines = client.scan_engines.get_pool_engines(pool_id=6)
+print(f"Pool has {len(engines['resources'])} engines")
+
+# Replace engines in pool
+result = client.scan_engines.set_pool_engines(
+    pool_id=6,
+    engine_ids=[1, 2, 3, 4, 5]
+)
+```
+
+### Get Pools for an Engine
+
+Find all pools that a scan engine belongs to:
+
+```python
+pools = client.scan_engines.get_engine_pools(engine_id=6)
+
+for pool in pools['resources']:
+    print(f"Engine is in pool: {pool['name']}")
+```
+
+## Shared Secret Operations
+
+### Revoke Shared Secret
+
+Revoke the current shared secret used for pairing engines:
+
+```python
+# Prevents new engines from being paired
+result = client.scan_engines.delete_shared_secret()
+```
+
+## Helper Methods
+
+### Get Available Engines
+
+Filter engines by status to get only available ones:
+
+```python
+available = client.scan_engines.get_available_engines()
+print(f"{len(available)} engines available for scanning")
+
+for engine in available:
+    print(f"- {engine['name']}: {engine['status']}")
+```
+
+### Get Engine Summary
+
+Get a comprehensive summary including sites and pools:
+
+```python
+summary = client.scan_engines.get_engine_summary(engine_id=6)
+
+print(f"Engine: {summary['engine']['name']}")
+print(f"Total Sites: {summary['sites_count']}")
+print(f"Pools: {len(summary['pools'])}")
+
+for pool in summary['pools']:
+    print(f"- In pool: {pool['name']}")
+```
+
+### Assign Engine to Pool
+
+Add an engine to an existing pool:
+
+```python
+result = client.scan_engines.assign_engine_to_pool(
+    engine_id=6,
+    pool_id=2
+)
+print("Engine assigned to pool")
+```
+
+### Remove Engine from Pool
+
+Remove an engine from a pool:
+
+```python
+result = client.scan_engines.remove_engine_from_pool(
+    engine_id=6,
+    pool_id=2
+)
+print("Engine removed from pool")
+```
+
+## Common Use Cases
+
+### Monitor Engine Health
+
+Check the status and health of all scan engines:
+
+```python
+engines = client.scan_engines.list()
+
+for engine in engines['resources']:
+    status = engine['status'].lower()
+    name = engine['name']
+    
+    if status in ['active', 'running']:
+        print(f"✓ {name}: Healthy")
+    else:
+        print(f"✗ {name}: {status}")
+```
+
+### Create Load-Balanced Scanning Infrastructure
+
+Set up engine pools for distributed scanning:
+
+```python
+# Get all available engines
+available = client.scan_engines.get_available_engines()
+engine_ids = [e['id'] for e in available]
+
+# Split engines into pools
+half = len(engine_ids) // 2
+
+# Create production pool
+prod_pool = client.scan_engines.create_pool(
+    name="Production Pool",
+    engine_ids=engine_ids[:half]
+)
+
+# Create development pool
+dev_pool = client.scan_engines.create_pool(
+    name="Development Pool",
+    engine_ids=engine_ids[half:]
+)
+
+print(f"Production Pool: {len(engine_ids[:half])} engines")
+print(f"Development Pool: {len(engine_ids[half:])} engines")
+```
+
+### Audit Engine Assignments
+
+Review which engines are assigned to which sites:
+
+```python
+engines = client.scan_engines.list()
+
+for engine in engines['resources']:
+    print(f"\nEngine: {engine['name']}")
+    
+    sites = client.scan_engines.get_sites(
+        engine_id=engine['id'],
+        size=100
+    )
+    
+    print(f"Assigned to {sites['page']['totalResources']} sites:")
+    for site in sites['resources']:
+        print(f"  - {site['name']}")
+```
+
+### Reorganize Engine Pools
+
+Move engines between pools:
+
+```python
+# Remove engine from old pool
+client.scan_engines.remove_engine_from_pool(
+    engine_id=6,
+    pool_id=1  # Old pool
+)
+
+# Add engine to new pool
+client.scan_engines.assign_engine_to_pool(
+    engine_id=6,
+    pool_id=2  # New pool
+)
+
+print("Engine moved to new pool")
+```
+
+## Error Handling
+
+Handle common error scenarios:
+
+```python
+from requests.exceptions import HTTPError
+
+try:
+    engine = client.scan_engines.get(engine_id=999)
+except HTTPError as e:
+    if e.response.status_code == 404:
+        print("Engine not found")
+    elif e.response.status_code == 401:
+        print("Authentication failed")
+    else:
+        print(f"Error: {e}")
+```
+
+## Response Examples
+
+### Engine Response
+
+```json
+{
+  "id": 6,
+  "name": "Corporate Scan Engine 001",
+  "address": "corporate-scan-engine-001.acme.com",
+  "port": 40894,
+  "status": "active",
+  "productVersion": "6.6.123",
+  "contentVersion": "2024-10-07",
+  "serialNumber": "ABC123DEF456",
+  "isAWSPreAuthEngine": false,
+  "sites": [42, 43, 44],
+  "lastRefreshedDate": "2024-10-07T12:00:00Z",
+  "lastUpdatedDate": "2024-10-07T12:00:00Z",
+  "links": [
+    {
+      "href": "https://hostname:3780/api/3/scan_engines/6",
+      "rel": "self"
+    }
+  ]
+}
+```
+
+### Engine Pool Response
+
+```json
+{
+  "id": 6,
+  "name": "Corporate Scan Engine Pool 001",
+  "engines": [1, 2, 3],
+  "sites": [42, 43, 44],
+  "links": [
+    {
+      "href": "https://hostname:3780/api/3/scan_engine_pools/6",
+      "rel": "self"
+    }
+  ]
+}
+```
+
+## API Methods Reference
+
+### Scan Engine Operations
+- `list(**params)` - List all scan engines
+- `get(engine_id)` - Get engine details
+- `update(engine_id, **kwargs)` - Update engine
+- `delete(engine_id)` - Delete engine
+- `get_sites(engine_id, page, size, sort)` - Get assigned sites
+- `get_scans(engine_id, page, size, sort)` - Get executed scans
+
+### Engine Pool Operations
+- `list_pools(**params)` - List all engine pools
+- `get_pool(pool_id)` - Get pool details
+- `create_pool(name, engine_ids, **kwargs)` - Create pool
+- `update_pool(pool_id, **kwargs)` - Update pool
+- `delete_pool(pool_id)` - Delete pool
+- `get_pool_engines(pool_id)` - Get engines in pool
+- `set_pool_engines(pool_id, engine_ids)` - Set pool engines
+- `get_engine_pools(engine_id)` - Get pools for engine
+
+### Shared Secret Operations
+- `delete_shared_secret()` - Revoke shared secret
+
+### Helper Methods
+- `get_available_engines()` - Get active engines
+- `get_engine_summary(engine_id)` - Get comprehensive summary
+- `assign_engine_to_pool(engine_id, pool_id)` - Assign to pool
+- `remove_engine_from_pool(engine_id, pool_id)` - Remove from pool
+
+## Best Practices
+
+1. **Monitor Engine Health**: Regularly check engine status
+2. **Use Engine Pools**: Distribute load across multiple engines
+3. **Plan Capacity**: Ensure engines can handle site assignments
+4. **Audit Assignments**: Regularly review engine-to-site mappings
+5. **Secure Pairing**: Manage shared secrets carefully
+
+## See Also
+
+- [Sites API Documentation](SITE_MANAGEMENT.md) - Managing sites that use engines
+- [Scans API Documentation](SCANS_API.md) - Managing scans run on engines
+- [API Reference](API_REFERENCE.md) - Complete API documentation

--- a/src/rapid7/api/scan_engines.py
+++ b/src/rapid7/api/scan_engines.py
@@ -1,0 +1,497 @@
+"""
+Module for Scan Engines API operations.
+
+This module provides a comprehensive interface for managing scan engines and
+engine pools through the InsightVM API v3. It supports full CRUD operations,
+health monitoring, site assignments, and pool management.
+"""
+
+from typing import Dict, Any, List, Optional, Tuple
+from .base import BaseAPI
+
+
+class ScanEngineAPI(BaseAPI):
+    """
+    API client for Scan Engine operations.
+    
+    This class provides methods for managing scan engines and engine pools,
+    including creating, updating, deleting engines, managing engine pools,
+    and monitoring engine health and assignments.
+    
+    All methods return JSON responses from the API.
+    
+    Example:
+        >>> from rapid7 import InsightVMClient
+        >>> client = InsightVMClient()
+        >>> 
+        >>> # List all scan engines
+        >>> engines = client.scan_engines.list()
+        >>> 
+        >>> # Get specific engine details
+        >>> engine = client.scan_engines.get(engine_id=6)
+        >>> 
+        >>> # Create engine pool
+        >>> pool = client.scan_engines.create_pool(
+        ...     name="Production Pool",
+        ...     engine_ids=[1, 2, 3]
+        ... )
+    """
+    
+    def __init__(
+        self,
+        auth,
+        verify_ssl: Optional[bool] = None,
+        timeout: Tuple[int, int] = (10, 90)
+    ):
+        """
+        Initialize the ScanEngineAPI client.
+        
+        Args:
+            auth: Authentication object (InsightVMAuth instance)
+            verify_ssl: Whether to verify SSL certificates
+            timeout: Tuple of (connect_timeout, read_timeout) in seconds
+        """
+        super().__init__(auth, verify_ssl, timeout)
+    
+    # ==================== Scan Engine Operations ====================
+    
+    def list(self, **params) -> Dict[str, Any]:
+        """
+        List all scan engines available for scanning.
+        
+        Returns scan engines with details including address, status, version,
+        assigned sites, and whether it's an AWS pre-authorized engine.
+        
+        Args:
+            **params: Optional query parameters (currently none supported by API)
+        
+        Returns:
+            Dictionary containing:
+                - resources: List of scan engine objects
+                - links: Hypermedia links
+        
+        Example:
+            >>> engines = client.scan_engines.list()
+            >>> for engine in engines['resources']:
+            ...     print(f"{engine['name']}: {engine['status']}")
+        """
+        return self._request('GET', 'scan_engines', params=params)
+    
+    def get(self, engine_id: int) -> Dict[str, Any]:
+        """
+        Get details for a specific scan engine.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+        
+        Returns:
+            Dictionary containing scan engine details including:
+                - id: Engine identifier
+                - name: Engine name
+                - address: Engine hostname/IP
+                - port: Engine port number
+                - status: Current status
+                - productVersion: Engine software version
+                - contentVersion: Content/vulnerability definitions version
+                - sites: List of assigned site IDs
+                - links: Hypermedia links
+        
+        Example:
+            >>> engine = client.scan_engines.get(6)
+            >>> print(f"Engine: {engine['name']} ({engine['address']})")
+            >>> print(f"Status: {engine['status']}")
+        """
+        return self._request('GET', f'scan_engines/{engine_id}')
+    
+    def update(self, engine_id: int, **kwargs) -> Dict[str, Any]:
+        """
+        Update configuration for an existing scan engine.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+            **kwargs: Engine properties to update (name, address, port, etc.)
+        
+        Returns:
+            Dictionary containing update confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.update(
+            ...     engine_id=6,
+            ...     name="Updated Engine Name"
+            ... )
+        """
+        return self._request('PUT', f'scan_engines/{engine_id}', json=kwargs)
+    
+    def delete(self, engine_id: int) -> Dict[str, Any]:
+        """
+        Delete a scan engine.
+        
+        Removes the scan engine from the system. The engine must not be
+        actively scanning or assigned to any sites.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+        
+        Returns:
+            Dictionary containing deletion confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.delete(6)
+        """
+        return self._request('DELETE', f'scan_engines/{engine_id}')
+    
+    # ==================== Scan Engine Sites ====================
+    
+    def get_sites(self, engine_id: int, page: int = 0, size: int = 10, 
+                  sort: Optional[List[str]] = None) -> Dict[str, Any]:
+        """
+        Get the list of sites assigned to a scan engine.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+            page: The page number to retrieve (zero-based)
+            size: The number of records per page
+            sort: Sort criteria in format 'property[,ASC|DESC]'
+        
+        Returns:
+            Dictionary containing:
+                - resources: List of site objects
+                - page: Pagination information
+                - links: Hypermedia links
+        
+        Example:
+            >>> sites = client.scan_engines.get_sites(engine_id=6, size=50)
+            >>> print(f"Engine assigned to {len(sites['resources'])} sites")
+        """
+        params = {'page': page, 'size': size}
+        if sort:
+            params['sort'] = sort
+        return self._request('GET', f'scan_engines/{engine_id}/sites', params=params)
+    
+    def get_scans(self, engine_id: int, page: int = 0, size: int = 10,
+                  sort: Optional[List[str]] = None) -> Dict[str, Any]:
+        """
+        Get scans that have been executed on a scan engine.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+            page: The page number to retrieve (zero-based)
+            size: The number of records per page
+            sort: Sort criteria in format 'property[,ASC|DESC]'
+        
+        Returns:
+            Dictionary containing:
+                - resources: List of scan objects
+                - page: Pagination information
+                - links: Hypermedia links
+        
+        Example:
+            >>> scans = client.scan_engines.get_scans(engine_id=6)
+            >>> for scan in scans['resources']:
+            ...     print(f"Scan {scan['id']}: {scan['status']}")
+        """
+        params = {'page': page, 'size': size}
+        if sort:
+            params['sort'] = sort
+        return self._request('GET', f'scan_engines/{engine_id}/scans', params=params)
+    
+    # ==================== Engine Pool Operations ====================
+    
+    def list_pools(self, **params) -> Dict[str, Any]:
+        """
+        List all engine pools available for scanning.
+        
+        Engine pools group multiple scan engines together for load balancing
+        and high availability scanning.
+        
+        Args:
+            **params: Optional query parameters (currently none supported by API)
+        
+        Returns:
+            Dictionary containing:
+                - resources: List of engine pool objects
+                - links: Hypermedia links
+        
+        Example:
+            >>> pools = client.scan_engines.list_pools()
+            >>> for pool in pools['resources']:
+            ...     print(f"{pool['name']}: {len(pool['engines'])} engines")
+        """
+        return self._request('GET', 'scan_engine_pools', params=params)
+    
+    def get_pool(self, pool_id: int) -> Dict[str, Any]:
+        """
+        Get details for a specific engine pool.
+        
+        Args:
+            pool_id: The identifier of the engine pool
+        
+        Returns:
+            Dictionary containing pool details including:
+                - id: Pool identifier
+                - name: Pool name
+                - engines: List of engine IDs in the pool
+                - sites: List of site IDs using this pool
+                - links: Hypermedia links
+        
+        Example:
+            >>> pool = client.scan_engines.get_pool(6)
+            >>> print(f"Pool: {pool['name']}")
+            >>> print(f"Engines: {pool['engines']}")
+        """
+        return self._request('GET', f'scan_engine_pools/{pool_id}')
+    
+    def create_pool(self, name: str, engine_ids: Optional[List[int]] = None,
+                    **kwargs) -> Dict[str, Any]:
+        """
+        Create a new engine pool.
+        
+        Engine pools group multiple scan engines for load balancing and
+        high availability.
+        
+        Args:
+            name: Name for the engine pool
+            engine_ids: List of scan engine IDs to include in the pool
+            **kwargs: Additional pool properties
+        
+        Returns:
+            Dictionary containing:
+                - id: New pool identifier
+                - links: Hypermedia links
+        
+        Example:
+            >>> pool = client.scan_engines.create_pool(
+            ...     name="Production Pool",
+            ...     engine_ids=[1, 2, 3]
+            ... )
+            >>> print(f"Created pool {pool['id']}")
+        """
+        data = {'name': name, **kwargs}
+        if engine_ids is not None:
+            data['engines'] = engine_ids
+        return self._request('POST', 'scan_engine_pools', json=data)
+    
+    def update_pool(self, pool_id: int, **kwargs) -> Dict[str, Any]:
+        """
+        Update an existing engine pool.
+        
+        Args:
+            pool_id: The identifier of the engine pool
+            **kwargs: Pool properties to update (name, engines, etc.)
+        
+        Returns:
+            Dictionary containing update confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.update_pool(
+            ...     pool_id=6,
+            ...     name="Updated Pool Name"
+            ... )
+        """
+        return self._request('PUT', f'scan_engine_pools/{pool_id}', json=kwargs)
+    
+    def delete_pool(self, pool_id: int) -> Dict[str, Any]:
+        """
+        Delete an engine pool.
+        
+        Args:
+            pool_id: The identifier of the engine pool
+        
+        Returns:
+            Dictionary containing deletion confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.delete_pool(6)
+        """
+        return self._request('DELETE', f'scan_engine_pools/{pool_id}')
+    
+    def get_pool_engines(self, pool_id: int) -> Dict[str, Any]:
+        """
+        Get the list of engines in an engine pool.
+        
+        Args:
+            pool_id: The identifier of the engine pool
+        
+        Returns:
+            Dictionary containing:
+                - resources: List of engine IDs in the pool
+                - links: Hypermedia links
+        
+        Example:
+            >>> engines = client.scan_engines.get_pool_engines(6)
+            >>> print(f"Pool has {len(engines['resources'])} engines")
+        """
+        return self._request('GET', f'scan_engine_pools/{pool_id}/engines')
+    
+    def set_pool_engines(self, pool_id: int, engine_ids: List[int]) -> Dict[str, Any]:
+        """
+        Set the engines in an engine pool.
+        
+        This replaces the current list of engines in the pool with the
+        provided list.
+        
+        Args:
+            pool_id: The identifier of the engine pool
+            engine_ids: List of scan engine IDs to place in the pool
+        
+        Returns:
+            Dictionary containing update confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.set_pool_engines(
+            ...     pool_id=6,
+            ...     engine_ids=[1, 2, 3, 4]
+            ... )
+        """
+        return self._request('PUT', f'scan_engine_pools/{pool_id}/engines', 
+                           json=engine_ids)
+    
+    def get_engine_pools(self, engine_id: int) -> Dict[str, Any]:
+        """
+        Get the pools that a scan engine is assigned to.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+        
+        Returns:
+            Dictionary containing:
+                - resources: List of engine pool objects
+                - links: Hypermedia links
+        
+        Example:
+            >>> pools = client.scan_engines.get_engine_pools(engine_id=6)
+            >>> for pool in pools['resources']:
+            ...     print(f"Engine in pool: {pool['name']}")
+        """
+        return self._request('GET', f'scan_engines/{engine_id}/scan_engine_pools')
+    
+    # ==================== Shared Secret Operations ====================
+    
+    def delete_shared_secret(self) -> Dict[str, Any]:
+        """
+        Revoke the current valid shared secret for scan engines.
+        
+        The shared secret is used for pairing new scan engines with the
+        console. Revoking it prevents new engines from being paired until
+        a new secret is generated.
+        
+        Returns:
+            Dictionary containing revocation confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.delete_shared_secret()
+        """
+        return self._request('DELETE', 'scan_engines/shared_secret')
+    
+    # ==================== Helper Methods ====================
+    
+    def get_available_engines(self) -> List[Dict[str, Any]]:
+        """
+        Get list of all available (active) scan engines.
+        
+        Helper method that filters engines by status to return only
+        those currently available for scanning.
+        
+        Returns:
+            List of available scan engine objects
+        
+        Example:
+            >>> engines = client.scan_engines.get_available_engines()
+            >>> print(f"{len(engines)} engines available")
+        """
+        response = self.list()
+        engines = response.get('resources', [])
+        # Filter by status if status field is present
+        return [e for e in engines if e.get('status', '').lower() in ['active', 'running', '']]
+    
+    def get_engine_summary(self, engine_id: int) -> Dict[str, Any]:
+        """
+        Get a summary of engine details including sites and pools.
+        
+        Helper method that combines engine details with site and pool
+        assignments for a comprehensive view.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+        
+        Returns:
+            Dictionary containing:
+                - engine: Engine details
+                - sites_count: Number of assigned sites
+                - pools: List of assigned pools
+        
+        Example:
+            >>> summary = client.scan_engines.get_engine_summary(6)
+            >>> print(f"Engine: {summary['engine']['name']}")
+            >>> print(f"Sites: {summary['sites_count']}")
+            >>> print(f"Pools: {len(summary['pools'])}")
+        """
+        engine = self.get(engine_id)
+        sites = self.get_sites(engine_id, size=1)
+        pools = self.get_engine_pools(engine_id)
+        
+        return {
+            'engine': engine,
+            'sites_count': sites.get('page', {}).get('totalResources', 0),
+            'pools': pools.get('resources', [])
+        }
+    
+    def assign_engine_to_pool(self, engine_id: int, pool_id: int) -> Dict[str, Any]:
+        """
+        Assign a scan engine to an engine pool.
+        
+        Helper method that adds an engine to a pool's engine list.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+            pool_id: The identifier of the engine pool
+        
+        Returns:
+            Dictionary containing update confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.assign_engine_to_pool(
+            ...     engine_id=6,
+            ...     pool_id=2
+            ... )
+        """
+        # Get current engines in pool
+        current = self.get_pool_engines(pool_id)
+        current_engines = current.get('resources', [])
+        
+        # Add new engine if not already present
+        if engine_id not in current_engines:
+            current_engines.append(engine_id)
+        
+        # Update pool with new engine list
+        return self.set_pool_engines(pool_id, current_engines)
+    
+    def remove_engine_from_pool(self, engine_id: int, pool_id: int) -> Dict[str, Any]:
+        """
+        Remove a scan engine from an engine pool.
+        
+        Helper method that removes an engine from a pool's engine list.
+        
+        Args:
+            engine_id: The identifier of the scan engine
+            pool_id: The identifier of the engine pool
+        
+        Returns:
+            Dictionary containing update confirmation and links
+        
+        Example:
+            >>> result = client.scan_engines.remove_engine_from_pool(
+            ...     engine_id=6,
+            ...     pool_id=2
+            ... )
+        """
+        # Get current engines in pool
+        current = self.get_pool_engines(pool_id)
+        current_engines = current.get('resources', [])
+        
+        # Remove engine if present
+        if engine_id in current_engines:
+            current_engines.remove(engine_id)
+        
+        # Update pool with new engine list
+        return self.set_pool_engines(pool_id, current_engines)

--- a/src/rapid7/client.py
+++ b/src/rapid7/client.py
@@ -12,6 +12,7 @@ from .api.assets import AssetAPI
 from .api.asset_groups import AssetGroupAPI
 from .api.reports import ReportsAPI
 from .api.scans import ScansAPI
+from .api.scan_engines import ScanEngineAPI
 from .api.sites import SiteAPI
 from .api.sonar_queries import SonarQueryAPI
 
@@ -30,6 +31,7 @@ class InsightVMClient:
         sonar_queries (SonarQueryAPI): Sonar query operations client
         sites (SiteAPI): Site operations client
         scans (ScansAPI): Scan operations client
+        scan_engines (ScanEngineAPI): Scan engine operations client
         reports (ReportsAPI): Report operations client
     
     Example:
@@ -119,6 +121,9 @@ class InsightVMClient:
             self.auth, verify_ssl=verify_ssl, timeout=timeout
         )
         self.scans = ScansAPI(
+            self.auth, verify_ssl=verify_ssl, timeout=timeout
+        )
+        self.scan_engines = ScanEngineAPI(
             self.auth, verify_ssl=verify_ssl, timeout=timeout
         )
         self.reports = ReportsAPI(


### PR DESCRIPTION
## Overview

Implements comprehensive Scan Engines API module for managing scan engines and engine pools in InsightVM.

## Changes

### New Files
- ✅ `src/rapid7/api/scan_engines.py` - ScanEngineAPI class (~480 lines)
- ✅ `docs/SCAN_ENGINES_API.md` - Complete API documentation

### Modified Files
- ✅ `src/rapid7/client.py` - Added scan_engines sub-client integration

## Features Implemented

### Scan Engine Operations
- ✅ List all scan engines
- ✅ Get engine details
- ✅ Update engine configuration
- ✅ Delete engine
- ✅ Get sites assigned to engine
- ✅ Get scans run on engine

### Engine Pool Operations
- ✅ List all engine pools
- ✅ Get pool details
- ✅ Create engine pool
- ✅ Update engine pool
- ✅ Delete engine pool
- ✅ Get engines in pool
- ✅ Set engines in pool
- ✅ Get pools for engine

### Shared Secret Operations
- ✅ Revoke shared secret

### Helper Methods
- ✅ Get available engines (filter by status)
- ✅ Get engine summary (engines + sites + pools)
- ✅ Assign engine to pool
- ✅ Remove engine from pool

## Integration

```python
from rapid7 import InsightVMClient

client = InsightVMClient()

# List engines
engines = client.scan_engines.list()

# Create pool
pool = client.scan_engines.create_pool(
    name="Production Pool",
    engine_ids=[1, 2, 3]
)

# Get engine summary
summary = client.scan_engines.get_engine_summary(6)
```

## Documentation

✅ Complete documentation in `docs/SCAN_ENGINES_API.md` including:
- Quick start guide
- All API operations with examples
- Common use cases
- Error handling
- Response examples
- Best practices

## Testing

- [x] Module follows BaseAPI inheritance pattern
- [x] All methods use direct `_request()` calls (standardized pattern)
- [x] Integrated with InsightVMClient
- [x] Comprehensive docstrings with type hints
- [x] Documentation complete

## Sprint Progress

**Sprint 3: Core Operations** (50% → 75% complete)
- ✅ Issue #66: Scans API Module
- ✅ Issue #67: Reports API Module
- ✅ Issue #68: Scan Engines API Module (this PR)
- ⏭️ Issue #69: Scan Templates API Module (next)

## Closes

Fixes #68