### PR TITLE
fix(scan_engines): rename methods to avoid BaseAPI conflicts

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -125,7 +125,47 @@ results = client.assets.search(criteria)
 all_assets = client.assets.get_all(batch_size=500)
 ```
 
-### 5. Migrate Asset Group Operations
+### 5. Migrate Scan Engines API Operations
+
+**v1.0 - Function-based (Not present in v1.0):**
+```python
+# Scan Engines were not available in v1.0
+```
+
+**v2.0 - Client methods with updated names:**
+```python
+from rapid7 import InsightVMClient
+
+client = InsightVMClient()
+
+# Get engine details (METHOD NAME CHANGED)
+engine = client.scan_engines.get_engine(engine_id=6)  # Was: .get()
+
+# Update engine (METHOD NAME CHANGED)
+result = client.scan_engines.update_engine(
+    engine_id=6,
+    name="New Name"
+)  # Was: .update()
+
+# Delete engine (METHOD NAME CHANGED)
+result = client.scan_engines.delete_engine(engine_id=6)  # Was: .delete()
+
+# Other methods remain unchanged
+pools = client.scan_engines.list_pools()
+summary = client.scan_engines.get_engine_summary(engine_id=6)
+```
+
+**⚠️ Breaking Change in v2.0.x:** Three scan engine methods were renamed to avoid conflicts with the parent `BaseAPI` class methods:
+
+| Old Method | New Method | Reason |
+|-----------|-----------|---------|
+| `get(engine_id)` | `get_engine(engine_id)` | Conflicted with `BaseAPI.get(endpoint, ...)` |
+| `update(engine_id, ...)` | `update_engine(engine_id, ...)` | Consistency with `get_engine` |
+| `delete(engine_id)` | `delete_engine(engine_id)` | Conflicted with `BaseAPI.delete(endpoint, ...)` |
+
+**Why this change?** The original method names violated the Liskov Substitution Principle by overriding parent class methods with incompatible signatures. The new names are more explicit and prevent inheritance issues.
+
+### 6. Migrate Asset Group Operations
 
 **v1.0 - Function-based:**
 ```python

--- a/README.md
+++ b/README.md
@@ -429,6 +429,10 @@ The v2.0 release has been tested against live InsightVM instances:
 - ✅ Sonar query integration
 
 **Breaking Changes:**
+- ⚠️ **Scan Engines API Method Renames** (v2.0.x): Three methods renamed to avoid BaseAPI conflicts
+  - `get(engine_id)` → `get_engine(engine_id)`
+  - `update(engine_id)` → `update_engine(engine_id)`
+  - `delete(engine_id)` → `delete_engine(engine_id)`
 - ⚠️ **Sites API Standardization**: Custom helper methods moved to `SiteManagementTools`
 - ⚠️ See [MIGRATION.md](MIGRATION.md) for complete upgrade guide from v1.0
 - ⚠️ See [SITE_MANAGEMENT.md](docs/SITE_MANAGEMENT.md) for Sites API migration details

--- a/docs/SCAN_ENGINES_API.md
+++ b/docs/SCAN_ENGINES_API.md
@@ -18,7 +18,7 @@ for engine in engines['resources']:
     print(f"{engine['name']}: {engine['status']}")
 
 # Get specific engine details
-engine = client.scan_engines.get(engine_id=6)
+engine = client.scan_engines.get_engine(engine_id=6)
 print(f"Engine: {engine['name']} at {engine['address']}")
 
 # Create an engine pool
@@ -56,7 +56,7 @@ for engine in engines['resources']:
 Retrieve detailed information for a specific scan engine:
 
 ```python
-engine = client.scan_engines.get(engine_id=6)
+engine = client.scan_engines.get_engine(engine_id=6)
 
 print(f"Engine Name: {engine['name']}")
 print(f"Address: {engine['address']}:{engine['port']}")
@@ -69,7 +69,7 @@ print(f"Assigned to {len(engine['sites'])} sites")
 Update scan engine configuration:
 
 ```python
-result = client.scan_engines.update(
+result = client.scan_engines.update_engine(
     engine_id=6,
     name="Updated Engine Name"
 )
@@ -81,7 +81,7 @@ Remove a scan engine from the system:
 
 ```python
 # Engine must not be actively scanning or assigned to sites
-result = client.scan_engines.delete(engine_id=6)
+result = client.scan_engines.delete_engine(engine_id=6)
 ```
 
 ## Engine Site Operations
@@ -370,7 +370,7 @@ Handle common error scenarios:
 from requests.exceptions import HTTPError
 
 try:
-    engine = client.scan_engines.get(engine_id=999)
+    engine = client.scan_engines.get_engine(engine_id=999)
 except HTTPError as e:
     if e.response.status_code == 404:
         print("Engine not found")
@@ -428,9 +428,9 @@ except HTTPError as e:
 
 ### Scan Engine Operations
 - `list(**params)` - List all scan engines
-- `get(engine_id)` - Get engine details
-- `update(engine_id, **kwargs)` - Update engine
-- `delete(engine_id)` - Delete engine
+- `get_engine(engine_id)` - Get engine details
+- `update_engine(engine_id, **kwargs)` - Update engine
+- `delete_engine(engine_id)` - Delete engine
 - `get_sites(engine_id, page, size, sort)` - Get assigned sites
 - `get_scans(engine_id, page, size, sort)` - Get executed scans
 


### PR DESCRIPTION
## Summary

Renames three methods in `ScanEnginesAPI` to resolve Liskov Substitution Principle violations and method signature conflicts with the `BaseAPI` parent class.

## Breaking Changes ⚠️

Three methods have been renamed to avoid conflicts:
- `get(engine_id)` → `get_engine(engine_id)`
- `update(engine_id)` → `update_engine(engine_id)`
- `delete(engine_id)` → `delete_engine(engine_id)`

Users upgrading will need to update their code to use the new method names.

## Changes Made

### Code Changes
- **src/rapid7/api/scan_engines.py**
  - Renamed `get()` to `get_engine()`
  - Renamed `update()` to `update_engine()`
  - Renamed `delete()` to `delete_engine()`
  - Fixed internal call in `get_engine_summary()` to use renamed method
  - Added explicit type hints for sort parameters
  - Fixed `get_available_engines()` status filter (removed 'running', kept only 'active')

### Documentation Updates
- **docs/SCAN_ENGINES_API.md**
  - Updated all code examples with new method names
  - Updated API Methods Reference table
  - Updated Quick Start, Get/Update/Delete sections, Error Handling examples

- **MIGRATION.md**
  - Added new section "5. Migrate Scan Engines API Operations"
  - Included migration table showing old vs new method names
  - Added before/after code examples
  - Explained reason for change (LSP violation)

- **README.md**
  - Added breaking change notice to v2.0.0 section
  - Documented the three method renames

## Why This Change?

The original method names (`get`, `update`, `delete`) conflicted with methods in the `BaseAPI` parent class but had incompatible signatures:
- Parent class methods: `get(path)`, `update(path, data)`, `delete(path)`
- Child class methods: `get(engine_id)`, `update(engine_id, **kwargs)`, `delete(engine_id)`

This violated the Liskov Substitution Principle and caused Pylint/Mypy errors. The renamed methods are more descriptive and avoid inheritance conflicts.

## Testing

- ✅ Type checking (Mypy)
- ✅ Linting (Pylint, Flake8)
- ✅ All documentation examples updated
- ✅ Migration guide provided for users

## Files Changed

- `src/rapid7/api/scan_engines.py`
- `docs/SCAN_ENGINES_API.md`
- `MIGRATION.md`
- `README.md`